### PR TITLE
feat: add economy commands and fix prefix command

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -1,24 +1,10 @@
 // Este es el manejador de mensajes que usarán los sub-bots y el bot principal.
-import fs from 'fs';
-import path from 'path';
 import { commands, aliases, testCache, cooldowns } from './index.js';
 import config from './config.js';
+import { readSettingsDb } from '../lib/database.js';
 
 const COOLDOWN_SECONDS = 5;
 const RESPONSE_DELAY_MS = 2000;
-
-const dbPath = path.resolve('./database/groupSettings.json');
-
-function readSettingsDb() {
-  try {
-    if (!fs.existsSync(dbPath)) return {};
-    const data = fs.readFileSync(dbPath, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    console.error("Error leyendo la base de datos de ajustes:", error);
-    return {};
-  }
-}
 
 export async function handler(m, isSubBot = false) { // Se añade isSubBot para diferenciar
   const sock = this;

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+
+const usersDbPath = path.resolve('./database/users.json');
+const settingsDbPath = path.resolve('./database/groupSettings.json');
+
+// --- Funciones de Directorio ---
+function ensureDbDirectoryExists(dbPath) {
+    const dir = path.dirname(dbPath);
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+    }
+}
+
+// --- Funciones para 'users.json' ---
+export function readUsersDb() {
+  try {
+    if (!fs.existsSync(usersDbPath)) return {};
+    const data = fs.readFileSync(usersDbPath, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.error("Error leyendo la base de datos de usuarios:", error);
+    return {};
+  }
+}
+
+export function writeUsersDb(data) {
+  try {
+    ensureDbDirectoryExists(usersDbPath);
+    fs.writeFileSync(usersDbPath, JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error("Error escribiendo en la base de datos de usuarios:", error);
+  }
+}
+
+// --- Funciones para 'groupSettings.json' ---
+export function readSettingsDb() {
+  try {
+    if (!fs.existsSync(settingsDbPath)) return {};
+    const data = fs.readFileSync(settingsDbPath, 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.error("Error leyendo la base de datos de ajustes:", error);
+    return {};
+  }
+}
+
+export function writeSettingsDb(data) {
+  try {
+    ensureDbDirectoryExists(settingsDbPath);
+    fs.writeFileSync(settingsDbPath, JSON.stringify(data, null, 2));
+  } catch (error) {
+    console.error("Error escribiendo en la base de datos de ajustes:", error);
+  }
+}

--- a/plugins/balance.js
+++ b/plugins/balance.js
@@ -1,17 +1,4 @@
-import fs from 'fs';
-import path from 'path';
-
-const dbPath = path.resolve('./database/users.json');
-
-// Función para leer la base de datos de usuarios
-function readUsersDb() {
-  try {
-    const data = fs.readFileSync(dbPath, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    return {};
-  }
-}
+import { readUsersDb } from '../../lib/database.js';
 
 const balanceCommand = {
   name: "balance",

--- a/plugins/daily.js
+++ b/plugins/daily.js
@@ -1,0 +1,41 @@
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
+
+const COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 horas
+const DAILY_REWARD = 1000;
+
+const dailyCommand = {
+  name: "daily",
+  category: "economia",
+  description: "Reclama tu recompensa diaria de monedas.",
+  aliases: ["diario"],
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const lastDaily = user.lastDaily || 0;
+    const now = Date.now();
+
+    if (now - lastDaily < COOLDOWN_MS) {
+      const timeLeft = COOLDOWN_MS - (now - lastDaily);
+      const hoursLeft = Math.floor(timeLeft / (1000 * 60 * 60));
+      const minutesLeft = Math.ceil((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+      return sock.sendMessage(msg.key.remoteJid, { text: `Ya reclamaste tu recompensa diaria. Vuelve en ${hoursLeft} horas y ${minutesLeft} minutos.` }, { quoted: msg });
+    }
+
+    user.coins = (user.coins || 0) + DAILY_REWARD;
+    user.lastDaily = now;
+
+    writeUsersDb(usersDb);
+
+    const dailyMessage = `🎉 ¡Has reclamado tu recompensa diaria de *${DAILY_REWARD} coins*!\nTu nuevo saldo es *${user.coins} coins*.`;
+    await sock.sendMessage(msg.key.remoteJid, { text: dailyMessage }, { quoted: msg });
+  }
+};
+
+export default dailyCommand;

--- a/plugins/give.js
+++ b/plugins/give.js
@@ -1,0 +1,54 @@
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
+
+const giveCommand = {
+  name: "give",
+  category: "economia",
+  description: "Transfiere monedas a otro usuario.",
+  aliases: ["dar", "transferir"],
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const senderUser = usersDb[senderId];
+
+    if (!senderUser) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const mentionedJid = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0];
+    if (!mentionedJid) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Debes mencionar a un usuario para transferirle monedas. Ejemplo: `give @usuario 100`" }, { quoted: msg });
+    }
+
+    const targetUser = usersDb[mentionedJid];
+    if (!targetUser) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "El usuario mencionado no está registrado." }, { quoted: msg });
+    }
+
+    if (senderId === mentionedJid) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "No puedes darte monedas a ti mismo." }, { quoted: msg });
+    }
+
+    const amount = parseInt(args.find(arg => !arg.startsWith('@')));
+    if (isNaN(amount) || amount <= 0) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, introduce una cantidad válida para transferir." }, { quoted: msg });
+    }
+
+    if (senderUser.coins < amount) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes monedas. Saldo actual: ${senderUser.coins}` }, { quoted: msg });
+    }
+
+    senderUser.coins -= amount;
+    targetUser.coins += amount;
+
+    writeUsersDb(usersDb);
+
+    const giveMessage = `✅ Has transferido *${amount} coins* a *${targetUser.name}*.\n` +
+                        `Tu nuevo saldo: ${senderUser.coins} coins.\n` +
+                        `Nuevo saldo de ${targetUser.name}: ${targetUser.coins} coins.`;
+
+    await sock.sendMessage(msg.key.remoteJid, { text: giveMessage, contextInfo: { mentionedJid: [mentionedJid] } }, { quoted: msg });
+  }
+};
+
+export default giveCommand;

--- a/plugins/leaderboard.js
+++ b/plugins/leaderboard.js
@@ -1,0 +1,31 @@
+import { readUsersDb } from '../../lib/database.js';
+
+const leaderboardCommand = {
+  name: "leaderboard",
+  category: "economia",
+  description: "Muestra la tabla de clasificación de los usuarios más ricos.",
+  aliases: ["lb", "top"],
+
+  async execute({ sock, msg }) {
+    const usersDb = readUsersDb();
+    const users = Object.values(usersDb);
+
+    if (users.length === 0) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No hay usuarios registrados para mostrar en la clasificación." }, { quoted: msg });
+    }
+
+    // Ordenar usuarios por monedas en orden descendente
+    users.sort((a, b) => (b.coins || 0) - (a.coins || 0));
+
+    const topUsers = users.slice(0, 10);
+
+    let leaderboardMessage = "🏆 *Tabla de Clasificación Global* 🏆\n\n";
+    topUsers.forEach((user, index) => {
+      leaderboardMessage += `${index + 1}. *${user.name}* - ${user.coins || 0} coins\n`;
+    });
+
+    await sock.sendMessage(msg.key.remoteJid, { text: leaderboardMessage }, { quoted: msg });
+  }
+};
+
+export default leaderboardCommand;

--- a/plugins/prefix.js
+++ b/plugins/prefix.js
@@ -1,24 +1,4 @@
-import fs from 'fs';
-import path from 'path';
-
-const dbPath = path.resolve('./database/groupSettings.json');
-
-function readSettingsDb() {
-  try {
-    const data = fs.readFileSync(dbPath, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    return {};
-  }
-}
-
-function writeSettingsDb(data) {
-  try {
-    fs.writeFileSync(dbPath, JSON.stringify(data, null, 2));
-  } catch (error) {
-    console.error("Error escribiendo en la base de datos de ajustes:", error);
-  }
-}
+import { readSettingsDb, writeSettingsDb } from '../../lib/database.js';
 
 const prefixCommand = {
   name: "prefijo",

--- a/plugins/register.js
+++ b/plugins/register.js
@@ -1,27 +1,6 @@
-import fs from 'fs';
-import path from 'path';
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
 
-const dbPath = path.resolve('./database/users.json');
 const INITIAL_COINS = 1000;
-
-// Función para leer la base de datos de usuarios
-function readUsersDb() {
-  try {
-    const data = fs.readFileSync(dbPath, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    return {};
-  }
-}
-
-// Función para escribir en la base de datos de usuarios
-function writeUsersDb(data) {
-  try {
-    fs.writeFileSync(dbPath, JSON.stringify(data, null, 2));
-  } catch (error) {
-    console.error("Error escribiendo en la base de datos de usuarios:", error);
-  }
-}
 
 const registerCommand = {
   name: "reg",

--- a/plugins/rob.js
+++ b/plugins/rob.js
@@ -1,0 +1,75 @@
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
+
+const COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 horas
+const SUCCESS_CHANCE = 0.4; // 40% de éxito
+const PENALTY_AMOUNT = 150;
+
+const robCommand = {
+  name: "rob",
+  category: "economia",
+  description: "Intenta robar monedas a otro usuario. ¡Cuidado, puedes fallar!",
+  aliases: ["robar"],
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const robber = usersDb[senderId];
+
+    if (!robber) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const lastRob = robber.lastRob || 0;
+    const now = Date.now();
+    if (now - lastRob < COOLDOWN_MS) {
+        const timeLeft = COOLDOWN_MS - (now - lastRob);
+        const hoursLeft = Math.floor(timeLeft / (1000 * 60 * 60));
+        const minutesLeft = Math.ceil((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+        return sock.sendMessage(msg.key.remoteJid, { text: `Debes esperar ${hoursLeft}h y ${minutesLeft}m para volver a robar.` }, { quoted: msg });
+    }
+
+    const mentionedJid = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0];
+    if (!mentionedJid) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Debes mencionar a un usuario para robarle. Ejemplo: `rob @usuario`" }, { quoted: msg });
+    }
+
+    const victim = usersDb[mentionedJid];
+    if (!victim) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "El usuario mencionado no está registrado." }, { quoted: msg });
+    }
+
+    if (senderId === mentionedJid) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "No puedes robarte a ti mismo." }, { quoted: msg });
+    }
+
+    if ((victim.coins || 0) < PENALTY_AMOUNT) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "La víctima es demasiado pobre, no vale la pena el riesgo." }, { quoted: msg });
+    }
+
+    robber.lastRob = now; // Actualizar cooldown independientemente del resultado
+
+    if (Math.random() < SUCCESS_CHANCE) {
+      // Éxito
+      const stolenPercentage = Math.random() * (0.3 - 0.1) + 0.1; // Roba entre 10% y 30%
+      const stolenAmount = Math.floor(victim.coins * stolenPercentage);
+
+      robber.coins += stolenAmount;
+      victim.coins -= stolenAmount;
+
+      writeUsersDb(usersDb);
+
+      const successMessage = `🚨 ¡Robo exitoso! 🚨\n\nLe has robado *${stolenAmount} coins* a *${victim.name}*.`;
+      await sock.sendMessage(msg.key.remoteJid, { text: successMessage, contextInfo: { mentionedJid: [mentionedJid] } }, { quoted: msg });
+
+    } else {
+      // Fracaso
+      robber.coins = Math.max(0, robber.coins - PENALTY_AMOUNT);
+      writeUsersDb(usersDb);
+
+      const failMessage = `🚓 ¡Te atraparon! 🚓\n\nFallaste el robo y perdiste *${PENALTY_AMOUNT} coins* como multa.`;
+      await sock.sendMessage(msg.key.remoteJid, { text: failMessage }, { quoted: msg });
+    }
+  }
+};
+
+export default robCommand;

--- a/plugins/shop.js
+++ b/plugins/shop.js
@@ -1,0 +1,27 @@
+const shopItems = [
+  { name: "Caña de Pescar", price: 2500, description: "Aumenta tus ganancias en la pesca." },
+  { name: "Poción de Suerte", price: 7000, description: "Aumenta la probabilidad de éxito en los robos por 24h." },
+  { name: "Mascota Rara", price: 15000, description: "Demuestra tu estatus con una mascota exótica." },
+  { name: "Cofre del Tesoro", price: 50000, description: "Contiene una cantidad aleatoria de monedas (puede ser más o menos del precio)." }
+];
+
+const shopCommand = {
+  name: "shop",
+  category: "economia",
+  description: "Muestra la tienda de artículos.",
+  aliases: ["tienda"],
+
+  async execute({ sock, msg }) {
+    let shopMessage = "🛍️ *Tienda de Artículos* 🛍️\n\n";
+    shopMessage += "Usa el comando `buy <item>` para comprar.\n\n";
+
+    shopItems.forEach(item => {
+      shopMessage += `*${item.name}* - Precio: *${item.price} coins*\n`;
+      shopMessage += `> _${item.description}_\n\n`;
+    });
+
+    await sock.sendMessage(msg.key.remoteJid, { text: shopMessage }, { quoted: msg });
+  }
+};
+
+export default shopCommand;

--- a/plugins/unregister.js
+++ b/plugins/unregister.js
@@ -1,26 +1,4 @@
-import fs from 'fs';
-import path from 'path';
-
-const dbPath = path.resolve('./database/users.json');
-
-// Función para leer la base de datos de usuarios
-function readUsersDb() {
-  try {
-    const data = fs.readFileSync(dbPath, 'utf8');
-    return JSON.parse(data);
-  } catch (error) {
-    return {};
-  }
-}
-
-// Función para escribir en la base de datos de usuarios
-function writeUsersDb(data) {
-  try {
-    fs.writeFileSync(dbPath, JSON.stringify(data, null, 2));
-  } catch (error) {
-    console.error("Error escribiendo en la base de datos de usuarios:", error);
-  }
-}
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
 
 const unregisterCommand = {
   name: "unreg",

--- a/plugins/work.js
+++ b/plugins/work.js
@@ -1,0 +1,40 @@
+import { readUsersDb, writeUsersDb } from '../../lib/database.js';
+
+const COOLDOWN_MS = 60 * 60 * 1000; // 1 hora
+
+const workCommand = {
+  name: "work",
+  category: "economia",
+  description: "Trabaja para ganar monedas. Tiene un tiempo de espera de 1 hora.",
+  aliases: ["trabajar"],
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const lastWork = user.lastWork || 0;
+    const now = Date.now();
+
+    if (now - lastWork < COOLDOWN_MS) {
+      const timeLeft = COOLDOWN_MS - (now - lastWork);
+      const minutesLeft = Math.ceil(timeLeft / (1000 * 60));
+      return sock.sendMessage(msg.key.remoteJid, { text: `Debes esperar ${minutesLeft} minutos más para volver a trabajar.` }, { quoted: msg });
+    }
+
+    const earnings = Math.floor(Math.random() * (500 - 100 + 1)) + 100;
+    user.coins = (user.coins || 0) + earnings;
+    user.lastWork = now;
+
+    writeUsersDb(usersDb);
+
+    const workMessage = `💪 Has trabajado duro y ganaste *${earnings} coins*.\nTu nuevo saldo es *${user.coins} coins*.`;
+    await sock.sendMessage(msg.key.remoteJid, { text: workMessage }, { quoted: msg });
+  }
+};
+
+export default workCommand;


### PR DESCRIPTION
- Adds a suite of new economy commands: `work`, `daily`, `give`, `rob`, `leaderboard`, and `shop`.
- Fixes a bug in the `prefix` command where it would fail silently if the `database` directory did not exist.
- Refactors all database access functions into a single shared module (`lib/database.js`) to improve maintainability and reduce code duplication.