### PR TITLE
feat: add facebook video downloader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "node-cache": "^5.1.2",
         "pino": "^8.21.0",
         "qrcode-terminal": "^0.12.0",
+        "ruhend-scraper": "^9.0.8",
         "wa-sticker-formatter": "^4.4.4",
         "wikipedia": "^2.0.0",
         "ws": "^8.17.0",
@@ -37,6 +38,28 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@distube/ytdl-core": {
+      "name": "@ru-hend/ytdl-core",
+      "version": "4.16.15",
+      "resolved": "https://registry.npmjs.org/@ru-hend/ytdl-core/-/ytdl-core-4.16.15.tgz",
+      "integrity": "sha512-JfZ9oNJotoGtjejK1J0SlSIV4xPwWXQahqQ/9/ixIojFETH7zRdGFIkP82wkfrlFmMc6jUSVTcB48JonHunACg==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "npm:@ru-hend/http-cookie-agent",
+        "https-proxy-agent": "^7.0.6",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^5.1.2",
+        "undici": "npm:@ru-hend/undici"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -857,6 +880,15 @@
       "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2796,6 +2828,31 @@
         "readable-stream": "^3.1.1"
       }
     },
+    "node_modules/http-cookie-agent": {
+      "name": "@ru-hend/http-cookie-agent",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@ru-hend/http-cookie-agent/-/http-cookie-agent-7.0.2.tgz",
+      "integrity": "sha512-eElnDVfSX442h/Vn0DuJXOIubrnVTDBl/HrFkPoRR25WndADgu6nYuD74FcjMW4GcO5EANAgmyvW+aELSBkfjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.4"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "npm:@ru-hend/undici"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2810,6 +2867,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -3203,6 +3273,19 @@
         "lyrics-finder": "src/bin.js"
       }
     },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "license": "MIT",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3311,6 +3394,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/minimatch": {
@@ -4111,6 +4203,169 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ruhend-scraper": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/ruhend-scraper/-/ruhend-scraper-9.0.8.tgz",
+      "integrity": "sha512-92tB/7e0fhW+x0q0WY/9/tE0VcqiG3GzXpgi/Rql1+0PV6/lde3nNQaP9D/XxGZQsS4V5mtXtx8aZ8PDXMR97Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@distube/ytdl-core": "npm:@ru-hend/ytdl-core",
+        "cheerio": "1.0.0-rc.10",
+        "node-fetch": "^2.6.1",
+        "yt-search": "npm:@ru-hend/yt-search"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/cheerio": {
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+      "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^1.5.0",
+        "dom-serializer": "^1.3.2",
+        "domhandler": "^4.2.0",
+        "htmlparser2": "^6.1.0",
+        "parse5": "^6.0.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/cheerio-select": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.6.0.tgz",
+      "integrity": "sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "css-select": "^4.3.0",
+        "css-what": "^6.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/css-select": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/ruhend-scraper/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/htmlparser2": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/ruhend-scraper/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
+    "node_modules/ruhend-scraper/node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4168,6 +4423,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -4516,6 +4777,24 @@
         "node": ">= 18"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4552,6 +4831,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "node-cache": "^5.1.2",
     "pino": "^8.21.0",
     "qrcode-terminal": "^0.12.0",
+    "ruhend-scraper": "^9.0.8",
     "wa-sticker-formatter": "^4.4.4",
     "wikipedia": "^2.0.0",
     "ws": "^8.17.0",

--- a/plugins/facebook.js
+++ b/plugins/facebook.js
@@ -1,51 +1,67 @@
-import axios from 'axios';
+import { igdl } from 'ruhend-scraper';
 
 const facebookCommand = {
   name: "facebook",
   category: "descargas",
   description: "Descarga un video de Facebook desde un enlace.",
-  aliases: ["fb"],
+  aliases: ["fb", "fbdl"],
 
   async execute({ sock, msg, args }) {
     const url = args[0];
+    const fbRegex = /https?:\/\/(www\.)?(facebook\.com|fb\.watch)\/[^\s]+/i;
 
-    if (!url || !(url.includes('facebook.com') || url.includes('fb.watch'))) {
-      await sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona un enlace válido de Facebook." }, { quoted: msg });
-      return;
+    if (!url || !fbRegex.test(url)) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona un enlace válido de Facebook." }, { quoted: msg });
     }
 
-    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `Procesando enlace de Facebook...` }, { quoted: msg });
+    const sharkEmoji = '🦈';
+    const warningEmoji = '⚠️';
+    const waitingEmoji = '🌊';
+    const successEmoji = '✨';
+    const errorEmoji = '❌';
+    const oopsEmoji = '💢';
+
+    // No hay 'react' en este framework, así que enviamos un mensaje de espera
+    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `${waitingEmoji} Procesando tu video, buba...` }, { quoted: msg });
+
+    let res;
+    try {
+        res = await igdl(url);
+    } catch (e) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `${oopsEmoji} *Aww, algo salió mal desu~... ¡Revisa el enlace, buba!*` }, { quoted: msg });
+    }
+
+    let result = res.data;
+    if (!result || result.length === 0) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `${warningEmoji} *Nada de nada ~ no encontré nada que descargar... buba! 🦈💦*` }, { quoted: msg });
+    }
+
+    let data;
+    try {
+        data = result.find(i => i.resolution === "720p (HD)") || result.find(i => i.resolution === "360p (SD)");
+    } catch (e) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `${oopsEmoji} *Oopsie doopsie! Tuve problemas procesando los datos desu... 🦈💔*` }, { quoted: msg });
+    }
+
+    if (!data) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `${warningEmoji} *Eh?? No encontré una resolución buena, uwu~ 💦*` }, { quoted: msg });
+    }
 
     try {
-      const apiUrl = `https://api.dreaded.site/api/facebook?url=${encodeURIComponent(url)}`;
-
-      // Pedimos la respuesta como un buffer de datos binarios
-      const response = await axios.get(apiUrl, {
-        responseType: 'arraybuffer',
-        timeout: 120000
-      });
-
-      const videoBuffer = Buffer.from(response.data, 'binary');
-
-      if (!videoBuffer || videoBuffer.length < 1000) { // Chequeo simple de que el buffer no esté vacío
-        throw new Error("La API no devolvió un video válido.");
-      }
-
-      await sock.sendMessage(msg.key.remoteJid, {
-        video: videoBuffer,
-        mimetype: 'video/mp4',
-        caption: "Aquí tienes tu video de Facebook."
-      }, { quoted: msg });
-
-      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Video de Facebook enviado.`, edit: waitingMsg.key });
-
-    } catch (error) {
-      console.error("Error en el comando facebook:", error.message);
-      if (error.code === 'ECONNABORTED') {
-        await sock.sendMessage(msg.key.remoteJid, { text: "El servidor de descargas de Facebook tardó demasiado en responder." }, { quoted: msg });
-      } else {
-        await sock.sendMessage(msg.key.remoteJid, { text: "No se pudo descargar el video. El enlace podría ser inválido, privado o la API estar fallando." }, { quoted: msg });
-      }
+        await sock.sendMessage(
+            msg.key.remoteJid,
+            {
+                video: { url: data.url },
+                caption: `${sharkEmoji} *¡Aquí tienes, buba! Espero que te guste desu~ 🦈✨*`,
+                mimetype: 'video/mp4'
+            },
+            { quoted: msg }
+        );
+        // Editamos el mensaje de espera para confirmar el éxito
+        await sock.sendMessage(msg.key.remoteJid, { text: `${successEmoji} ¡Video enviado, buba!`, edit: waitingMsg.key });
+    } catch (e) {
+        console.error("Error al enviar video de Facebook:", e);
+        await sock.sendMessage(msg.key.remoteJid, { text: `${oopsEmoji} *¡Hyaaa! Algo falló al enviarte el video... ¡No te enojes conmigo desu~! 🦈💦*` }, { quoted: msg });
     }
   }
 };


### PR DESCRIPTION
Adds a new command to download videos from Facebook using the `ruhend-scraper` library as requested. The existing `plugins/facebook.js` file has been overwritten with the new, adapted logic.