### PR TITLE
feat: add image to menu command

### DIFF
--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -61,7 +61,15 @@ const menuCommand = {
 
     menuText += `╰───「 _by ${config.ownerName}_ 」───╯`;
 
-    await sock.sendMessage(msg.key.remoteJid, { text: menuText }, { quoted: msg });
+    await sock.sendMessage(
+      msg.key.remoteJid,
+      {
+        image: { url: 'https://files.catbox.moe/itgz1x.png' },
+        caption: menuText,
+        mimetype: 'image/png'
+      },
+      { quoted: msg }
+    );
   }
 };
 


### PR DESCRIPTION
Updates the menu command to send an image with the menu text as the caption, as requested by the user.