### PR TITLE
feat: replace gemini command with qwen api

### DIFF
--- a/plugins/gemini.js
+++ b/plugins/gemini.js
@@ -3,53 +3,31 @@ import axios from 'axios';
 const geminiCommand = {
   name: "gemini",
   category: "ias",
-  description: "Habla con la IA de Google, Gemini.",
+  description: "Habla con una IA (modelo Qwen).",
 
-  async execute({ sock, msg, args, config }) {
+  async execute({ sock, msg, args }) {
     const query = args.join(' ');
     if (!query) {
-      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, hazme una pregunta para que Gemini la responda." }, { quoted: msg });
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, hazme una pregunta." }, { quoted: msg });
     }
 
-    if (!config.api.gemini) {
-        return sock.sendMessage(msg.key.remoteJid, { text: "La API Key de Gemini no está configurada." }, { quoted: msg });
-    }
+    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: "🧠 Pensando..." }, { quoted: msg });
 
     try {
-      await sock.sendMessage(msg.key.remoteJid, { text: "🧠 Pensando..." }, { quoted: msg });
+      const apiUrl = `https://myapiadonix.vercel.app/ai/qwen?text=${encodeURIComponent(query)}`;
+      const response = await axios.get(apiUrl);
 
-      const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${config.api.gemini}`;
+      const result = response.data;
 
-      const requestBody = {
-        contents: [
-          {
-            parts: [
-              {
-                text: query
-              }
-            ]
-          }
-        ]
-      };
-
-      const response = await axios.post(apiUrl, requestBody, {
-        headers: {
-          'Content-Type': 'application/json'
-        }
-      });
-
-      // Extraer la respuesta del JSON anidado
-      const geminiResponse = response.data.candidates[0].content.parts[0].text;
-
-      if (!geminiResponse) {
-        throw new Error("No se pudo obtener una respuesta de Gemini.");
+      if (!result.status || !result.result) {
+        throw new Error("La respuesta de la API no fue exitosa o no contenía un resultado.");
       }
 
-      await sock.sendMessage(msg.key.remoteJid, { text: geminiResponse }, { quoted: msg });
+      await sock.sendMessage(msg.key.remoteJid, { text: result.result }, { quoted: msg, edit: waitingMsg.key });
 
     } catch (error) {
-      console.error("Error en el comando gemini:", error.response ? error.response.data : error.message);
-      await sock.sendMessage(msg.key.remoteJid, { text: "Ocurrió un error al contactar a la IA de Gemini. Verifica la API Key y la consulta." }, { quoted: msg });
+      console.error("Error en el comando gemini (qwen):", error.message);
+      await sock.sendMessage(msg.key.remoteJid, { text: "Ocurrió un error al contactar a la IA." }, { quoted: msg, edit: waitingMsg.key });
     }
   }
 };


### PR DESCRIPTION
Replaces the official Google Gemini API implementation in the `gemini` command with a new, public API for the Qwen model, as requested by the user. This removes the need for an API key.