### PR TITLE
feat: add advanced economy commands

### DIFF
--- a/lib/shop-items.js
+++ b/lib/shop-items.js
@@ -1,0 +1,6 @@
+export const shopItems = [
+  { id: "pesca", name: "Caña de Pescar", price: 2500, description: "Aumenta tus ganancias en la pesca." },
+  { id: "suerte", name: "Poción de Suerte", price: 7000, description: "Aumenta la probabilidad de éxito en los robos por 24h." },
+  { id: "mascota", name: "Mascota Rara", price: 15000, description: "Demuestra tu estatus con una mascota exótica." },
+  { id: "cofre", name: "Cofre del Tesoro", price: 50000, description: "Contiene una cantidad aleatoria de monedas (puede ser más o menos del precio)." }
+];

--- a/plugins/buy.js
+++ b/plugins/buy.js
@@ -1,0 +1,52 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import { shopItems } from '../lib/shop-items.js';
+
+const buyCommand = {
+  name: "buy",
+  category: "economia",
+  description: "Compra un artículo de la tienda.",
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const itemId = args[0];
+    if (!itemId) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, especifica el ID del artículo que quieres comprar. Usa el comando `shop` para ver los artículos." }, { quoted: msg });
+    }
+
+    const itemToBuy = shopItems.find(item => item.id.toLowerCase() === itemId.toLowerCase());
+
+    if (!itemToBuy) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No se encontró ningún artículo con el ID "${itemId}".` }, { quoted: msg });
+    }
+
+    if (user.coins < itemToBuy.price) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes monedas para comprar "${itemToBuy.name}". Necesitas ${itemToBuy.price} coins, pero solo tienes ${user.coins}.` }, { quoted: msg });
+    }
+
+    // Inicializar inventario si no existe
+    if (!user.inventory) {
+      user.inventory = {};
+    }
+
+    // Restar monedas y añadir artículo al inventario
+    user.coins -= itemToBuy.price;
+    user.inventory[itemToBuy.id] = (user.inventory[itemToBuy.id] || 0) + 1; // Añade o incrementa la cantidad
+
+    writeUsersDb(usersDb);
+
+    const successMessage = `🎉 ¡Has comprado "${itemToBuy.name}" por ${itemToBuy.price} coins!\n` +
+                           `Tu nuevo saldo es de ${user.coins} coins.\n` +
+                           `Usa el comando \`inventory\` para ver tus artículos.`;
+
+    await sock.sendMessage(msg.key.remoteJid, { text: successMessage }, { quoted: msg });
+  }
+};
+
+export default buyCommand;

--- a/plugins/crime.js
+++ b/plugins/crime.js
@@ -1,0 +1,59 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+
+const crimeCommand = {
+  name: "crime",
+  category: "economia",
+  description: "Comete un crimen para ganar (o perder) monedas. Mayor riesgo, mayor recompensa.",
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+    const COOLDOWN_MS = 2 * 60 * 60 * 1000; // 2 horas
+    const SUCCESS_CHANCE = 0.5; // 50%
+    const PENALTY_AMOUNT = 250;
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const lastCrime = user.lastCrime || 0;
+    const now = Date.now();
+
+    if (now - lastCrime < COOLDOWN_MS) {
+      const timeLeft = COOLDOWN_MS - (now - lastCrime);
+      const hoursLeft = Math.floor(timeLeft / (1000 * 60 * 60));
+      const minutesLeft = Math.ceil((timeLeft % (1000 * 60 * 60)) / (1000 * 60));
+      return sock.sendMessage(msg.key.remoteJid, { text: `Debes esperar ${hoursLeft}h y ${minutesLeft}m para volver a delinquir.` }, { quoted: msg });
+    }
+
+    user.lastCrime = now; // Actualizar cooldown
+
+    if (Math.random() < SUCCESS_CHANCE) {
+      // Éxito
+      const earnings = Math.floor(Math.random() * (2000 - 500 + 1)) + 500;
+      user.coins += earnings;
+      writeUsersDb(usersDb);
+      const successMessages = [
+        `Robaste un banco y escapaste con ${earnings} coins.`,
+        `Hackeaste una cuenta de criptomonedas y obtuviste ${earnings} coins.`,
+        `Realizaste un atraco exitoso y te llevaste ${earnings} coins.`
+      ];
+      const message = successMessages[Math.floor(Math.random() * successMessages.length)];
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ *¡Éxito!* ${message}\n*Nuevo saldo:* ${user.coins} coins` }, { quoted: msg });
+    } else {
+      // Fracaso
+      user.coins = Math.max(0, user.coins - PENALTY_AMOUNT);
+      writeUsersDb(usersDb);
+      const failMessages = [
+        `Intentaste robar una tienda pero te atraparon. Pagaste ${PENALTY_AMOUNT} coins de multa.`,
+        `Tu hackeo falló y tuviste que pagar ${PENALTY_AMOUNT} coins para cubrir tus huellas.`,
+        `La policía te detuvo en medio del atraco. Perdiste ${PENALTY_AMOUNT} coins.`
+      ];
+      const message = failMessages[Math.floor(Math.random() * failMessages.length)];
+      await sock.sendMessage(msg.key.remoteJid, { text: `❌ *¡Fracaso!* ${message}\n*Nuevo saldo:* ${user.coins} coins` }, { quoted: msg });
+    }
+  }
+};
+
+export default crimeCommand;

--- a/plugins/inventory.js
+++ b/plugins/inventory.js
@@ -1,0 +1,39 @@
+import { readUsersDb } from '../lib/database.js';
+import { shopItems } from '../lib/shop-items.js';
+
+const inventoryCommand = {
+  name: "inventory",
+  category: "economia",
+  description: "Muestra los artículos que posees.",
+  aliases: ["inv"],
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    if (!user.inventory || Object.keys(user.inventory).length === 0) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Tu inventario está vacío. Usa el comando `buy` para comprar artículos." }, { quoted: msg });
+    }
+
+    let inventoryMessage = "🎒 *Tu Inventario*\n\n";
+
+    for (const itemId in user.inventory) {
+      const item = shopItems.find(i => i.id === itemId);
+      const quantity = user.inventory[itemId];
+
+      if (item) {
+        inventoryMessage += `*${item.name}* x${quantity}\n`;
+        inventoryMessage += `> _${item.description}_\n\n`;
+      }
+    }
+
+    await sock.sendMessage(msg.key.remoteJid, { text: inventoryMessage }, { quoted: msg });
+  }
+};
+
+export default inventoryCommand;

--- a/plugins/shop.js
+++ b/plugins/shop.js
@@ -1,9 +1,4 @@
-const shopItems = [
-  { name: "Caña de Pescar", price: 2500, description: "Aumenta tus ganancias en la pesca." },
-  { name: "Poción de Suerte", price: 7000, description: "Aumenta la probabilidad de éxito en los robos por 24h." },
-  { name: "Mascota Rara", price: 15000, description: "Demuestra tu estatus con una mascota exótica." },
-  { name: "Cofre del Tesoro", price: 50000, description: "Contiene una cantidad aleatoria de monedas (puede ser más o menos del precio)." }
-];
+import { shopItems } from '../lib/shop-items.js';
 
 const shopCommand = {
   name: "shop",
@@ -13,11 +8,11 @@ const shopCommand = {
 
   async execute({ sock, msg }) {
     let shopMessage = "🛍️ *Tienda de Artículos* 🛍️\n\n";
-    shopMessage += "Usa el comando `buy <item>` para comprar.\n\n";
+    shopMessage += "Usa el comando `buy <ID del item>` para comprar.\n\n";
 
     shopItems.forEach(item => {
       shopMessage += `*${item.name}* - Precio: *${item.price} coins*\n`;
-      shopMessage += `> _${item.description}_\n\n`;
+      shopMessage += `> (ID: \`${item.id}\`) _${item.description}_\n\n`;
     });
 
     await sock.sendMessage(msg.key.remoteJid, { text: shopMessage }, { quoted: msg });

--- a/plugins/slots.js
+++ b/plugins/slots.js
@@ -1,0 +1,60 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+
+const slotsCommand = {
+  name: "slots",
+  category: "economia",
+  description: "Juega a la máquina tragamonedas. Uso: slots <cantidad>",
+  aliases: ["slot"],
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    const bet = parseInt(args[0]);
+    if (isNaN(bet) || bet <= 0) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, introduce una cantidad válida para apostar." }, { quoted: msg });
+    }
+
+    if (user.coins < bet) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes monedas para apostar. Saldo actual: ${user.coins}` }, { quoted: msg });
+    }
+
+    const emojis = ["🍒", "🍋", "🍊", "🍉", "🍇", "💎"];
+    const results = [
+      emojis[Math.floor(Math.random() * emojis.length)],
+      emojis[Math.floor(Math.random() * emojis.length)],
+      emojis[Math.floor(Math.random() * emojis.length)]
+    ];
+
+    const resultString = `[ ${results.join(" | ")} ]`;
+    let winAmount = 0;
+    let winMessage = "";
+
+    if (results[0] === results[1] && results[1] === results[2]) {
+      // 3 of a kind
+      winAmount = bet * 10;
+      winMessage = `¡JACKPOT! ¡Has ganado ${winAmount} coins! 🎉`;
+    } else if (results[0] === results[1] || results[1] === results[2] || results[0] === results[2]) {
+      // 2 of a kind
+      winAmount = bet * 2;
+      winMessage = `¡Dos iguales! ¡Has ganado ${winAmount} coins!`;
+    } else {
+      // No win
+      winAmount = -bet;
+      winMessage = `¡Mala suerte! Has perdido ${bet} coins.`;
+    }
+
+    user.coins += winAmount;
+    writeUsersDb(usersDb);
+
+    const finalMessage = `🎰 *Tragamonedas* 🎰\n\n${resultString}\n\n${winMessage}\n\n*Nuevo saldo:* ${user.coins} coins`;
+    await sock.sendMessage(msg.key.remoteJid, { text: finalMessage }, { quoted: msg });
+  }
+};
+
+export default slotsCommand;


### PR DESCRIPTION
- Adds four new economy commands: `buy`, `inventory`, `slots`, and `crime`.
- Centralizes shop item data into a new `lib/shop-items.js` module.
- Updates the `shop` command to use the shared item list and display item IDs.