### PR TITLE
feat: add setwelcome and setbye commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,28 +95,34 @@ async function connectToWhatsApp() {
   // La lógica de comandos se moverá a handler.js para ser reutilizable.
   sock.ev.on('messages.upsert', (m) => sock.handler(m, false)); // false porque este es el bot principal
 
-  // --- MANEJO DE BIENVENIDA ---
+  // --- MANEJO DE BIENVENIDA Y DESPEDIDA ---
   sock.ev.on('group-participants.update', async (event) => {
-      const { id, participants, action } = event;
-      const settingsDbPath = path.resolve('./database/groupSettings.json');
-      let settings = {};
-      try {
-        const data = fs.readFileSync(settingsDbPath, 'utf8');
-        settings = JSON.parse(data);
-      } catch (e) {}
+    const { id, participants, action } = event;
+    // Usamos la función centralizada de la base de datos
+    const { readSettingsDb } = await import('./lib/database.js');
+    const settings = readSettingsDb();
+    const groupSettings = settings[id];
 
-      if (!settings[id]?.welcome) return;
+    if (!groupSettings) return;
 
+    for (const p of participants) {
       try {
-        const metadata = await sock.groupMetadata(id);
-        for (const p of participants) {
-          const userName = `@${p.split('@')[0]}`;
-          const message = action === 'add'
-            ? `¡Bienvenido/a al grupo *${metadata.subject}*, ${userName}! 🎉`
-            : `Adiós, ${userName}. Te extrañaremos. 👋`;
+        const userName = `@${p.split('@')[0]}`;
+        let message = '';
+
+        if (action === 'add' && groupSettings.welcome && groupSettings.welcomeMessage) {
+          message = groupSettings.welcomeMessage.replace(/@user/g, userName);
+        } else if (action === 'remove' && groupSettings.bye && groupSettings.byeMessage) {
+          message = groupSettings.byeMessage.replace(/@user/g, userName);
+        }
+
+        if (message) {
           await sock.sendMessage(id, { text: message, mentions: [p] });
         }
-      } catch (e) { console.error("Error en group-participants.update:", e); }
+      } catch (e) {
+        console.error(`Error en group-participants.update para el participante ${p}:`, e);
+      }
+    }
   });
 
   return sock;

--- a/plugins/setbye.js
+++ b/plugins/setbye.js
@@ -1,0 +1,51 @@
+import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+
+const setByeCommand = {
+  name: "setbye",
+  category: "grupos",
+  description: "Establece un mensaje de despedida para el grupo. Usa @user para mencionar al miembro que se fue. Escribe 'off' para desactivarlo.",
+
+  async execute({ sock, msg, args }) {
+    const from = msg.key.remoteJid;
+    if (!from.endsWith('@g.us')) {
+      return sock.sendMessage(from, { text: "Este comando solo se puede usar en grupos." }, { quoted: msg });
+    }
+
+    // Verificar si el usuario es administrador del grupo
+    try {
+      const metadata = await sock.groupMetadata(from);
+      const senderId = msg.key.participant || msg.key.remoteJid;
+      const participant = metadata.participants.find(p => p.id === senderId);
+      if (!participant || !['admin', 'superadmin'].includes(participant.admin)) {
+        return sock.sendMessage(from, { text: "No tienes permisos de administrador para usar este comando." }, { quoted: msg });
+      }
+    } catch (e) {
+      return sock.sendMessage(from, { text: "Ocurrió un error al verificar tus permisos." }, { quoted: msg });
+    }
+
+    const settings = readSettingsDb();
+    const byeText = args.join(' ');
+
+    if (!settings[from]) {
+      settings[from] = {};
+    }
+
+    if (byeText.toLowerCase() === 'off' || byeText.toLowerCase() === 'disable') {
+      settings[from].bye = false;
+      writeSettingsDb(settings);
+      return sock.sendMessage(from, { text: "✅ Los mensajes de despedida han sido desactivados para este grupo." }, { quoted: msg });
+    }
+
+    if (!byeText) {
+        return sock.sendMessage(from, { text: "Por favor, proporciona un mensaje de despedida. Ejemplo: `setbye Adiós, @user.`" }, { quoted: msg });
+    }
+
+    settings[from].bye = true;
+    settings[from].byeMessage = byeText;
+    writeSettingsDb(settings);
+
+    await sock.sendMessage(from, { text: `✅ Mensaje de despedida establecido:\n\n"${byeText}"` }, { quoted: msg });
+  }
+};
+
+export default setByeCommand;

--- a/plugins/setwelcome.js
+++ b/plugins/setwelcome.js
@@ -1,0 +1,51 @@
+import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+
+const setWelcomeCommand = {
+  name: "setwelcome",
+  category: "grupos",
+  description: "Establece un mensaje de bienvenida para el grupo. Usa @user para mencionar al nuevo miembro. Escribe 'off' para desactivarlo.",
+
+  async execute({ sock, msg, args }) {
+    const from = msg.key.remoteJid;
+    if (!from.endsWith('@g.us')) {
+      return sock.sendMessage(from, { text: "Este comando solo se puede usar en grupos." }, { quoted: msg });
+    }
+
+    // Verificar si el usuario es administrador del grupo
+    try {
+      const metadata = await sock.groupMetadata(from);
+      const senderId = msg.key.participant || msg.key.remoteJid;
+      const participant = metadata.participants.find(p => p.id === senderId);
+      if (!participant || !['admin', 'superadmin'].includes(participant.admin)) {
+        return sock.sendMessage(from, { text: "No tienes permisos de administrador para usar este comando." }, { quoted: msg });
+      }
+    } catch (e) {
+      return sock.sendMessage(from, { text: "Ocurrió un error al verificar tus permisos." }, { quoted: msg });
+    }
+
+    const settings = readSettingsDb();
+    const welcomeText = args.join(' ');
+
+    if (!settings[from]) {
+      settings[from] = {};
+    }
+
+    if (welcomeText.toLowerCase() === 'off' || welcomeText.toLowerCase() === 'disable') {
+      settings[from].welcome = false;
+      writeSettingsDb(settings);
+      return sock.sendMessage(from, { text: "✅ Los mensajes de bienvenida han sido desactivados para este grupo." }, { quoted: msg });
+    }
+
+    if (!welcomeText) {
+        return sock.sendMessage(from, { text: "Por favor, proporciona un mensaje de bienvenida. Ejemplo: `setwelcome ¡Bienvenido @user al grupo!`" }, { quoted: msg });
+    }
+
+    settings[from].welcome = true;
+    settings[from].welcomeMessage = welcomeText;
+    writeSettingsDb(settings);
+
+    await sock.sendMessage(from, { text: `✅ Mensaje de bienvenida establecido:\n\n"${welcomeText}"` }, { quoted: msg });
+  }
+};
+
+export default setWelcomeCommand;


### PR DESCRIPTION
1. Adds `setwelcome` and `setbye` commands for group admins to configure custom welcome and goodbye messages.

- Updates the `group-participants.update` event handler in `index.js` to send these custom messages.
- The custom messages support an `@user` placeholder.