### PR TITLE
feat: implement tax system for economy commands

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,6 +10,9 @@ const config = {
   // El nombre del propietario del bot.
   ownerName: "YO SOY YO",
 
+  // Tasa de impuestos para la economía (ej. 0.10 para 10%)
+  taxRate: 0.10,
+
   // Números de los propietarios del bot (en formato de WhatsApp, ej: '5211234567890').
   // El bot puede tener funcionalidades exclusivas para estos números.
   // Se añade el LID del propietario para asegurar el reconocimiento.

--- a/plugins/crime.js
+++ b/plugins/crime.js
@@ -5,7 +5,7 @@ const crimeCommand = {
   category: "economia",
   description: "Comete un crimen para ganar (o perder) monedas. Mayor riesgo, mayor recompensa.",
 
-  async execute({ sock, msg }) {
+  async execute({ sock, msg, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const user = usersDb[senderId];
@@ -32,7 +32,10 @@ const crimeCommand = {
     if (Math.random() < SUCCESS_CHANCE) {
       // Éxito
       const earnings = Math.floor(Math.random() * (2000 - 500 + 1)) + 500;
-      user.coins += earnings;
+      const tax = Math.floor(earnings * config.taxRate);
+      const netEarnings = earnings - tax;
+
+      user.coins += netEarnings;
       writeUsersDb(usersDb);
       const successMessages = [
         `Robaste un banco y escapaste con ${earnings} coins.`,
@@ -40,7 +43,8 @@ const crimeCommand = {
         `Realizaste un atraco exitoso y te llevaste ${earnings} coins.`
       ];
       const message = successMessages[Math.floor(Math.random() * successMessages.length)];
-      await sock.sendMessage(msg.key.remoteJid, { text: `✅ *¡Éxito!* ${message}\n*Nuevo saldo:* ${user.coins} coins` }, { quoted: msg });
+      const taxMessage = `\n💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n💰 Ganancia neta: *${netEarnings} coins*.`;
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ *¡Éxito!* ${message}${taxMessage}\n\n*Nuevo saldo:* ${user.coins} coins` }, { quoted: msg });
     } else {
       // Fracaso
       user.coins = Math.max(0, user.coins - PENALTY_AMOUNT);

--- a/plugins/daily.js
+++ b/plugins/daily.js
@@ -9,7 +9,7 @@ const dailyCommand = {
   description: "Reclama tu recompensa diaria de monedas.",
   aliases: ["diario"],
 
-  async execute({ sock, msg }) {
+  async execute({ sock, msg, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const user = usersDb[senderId];
@@ -28,12 +28,18 @@ const dailyCommand = {
       return sock.sendMessage(msg.key.remoteJid, { text: `Ya reclamaste tu recompensa diaria. Vuelve en ${hoursLeft} horas y ${minutesLeft} minutos.` }, { quoted: msg });
     }
 
-    user.coins = (user.coins || 0) + DAILY_REWARD;
+    const tax = Math.floor(DAILY_REWARD * config.taxRate);
+    const netReward = DAILY_REWARD - tax;
+
+    user.coins = (user.coins || 0) + netReward;
     user.lastDaily = now;
 
     writeUsersDb(usersDb);
 
-    const dailyMessage = `🎉 ¡Has reclamado tu recompensa diaria de *${DAILY_REWARD} coins*!\nTu nuevo saldo es *${user.coins} coins*.`;
+    const dailyMessage = `🎉 ¡Has reclamado tu recompensa diaria de *${DAILY_REWARD} coins*!\n` +
+                         `💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n` +
+                         `💰 Ganancia neta: *${netReward} coins*.\n` +
+                         `🏦 Tu nuevo saldo es *${user.coins} coins*.`;
     await sock.sendMessage(msg.key.remoteJid, { text: dailyMessage }, { quoted: msg });
   }
 };

--- a/plugins/give.js
+++ b/plugins/give.js
@@ -6,7 +6,7 @@ const giveCommand = {
   description: "Transfiere monedas a otro usuario.",
   aliases: ["dar", "transferir"],
 
-  async execute({ sock, msg, args }) {
+  async execute({ sock, msg, args, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const senderUser = usersDb[senderId];
@@ -38,14 +38,18 @@ const giveCommand = {
       return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes monedas. Saldo actual: ${senderUser.coins}` }, { quoted: msg });
     }
 
+    const tax = Math.floor(amount * config.taxRate);
+    const netAmount = amount - tax;
+
     senderUser.coins -= amount;
-    targetUser.coins += amount;
+    targetUser.coins += netAmount;
 
     writeUsersDb(usersDb);
 
     const giveMessage = `✅ Has transferido *${amount} coins* a *${targetUser.name}*.\n` +
-                        `Tu nuevo saldo: ${senderUser.coins} coins.\n` +
-                        `Nuevo saldo de ${targetUser.name}: ${targetUser.coins} coins.`;
+                        `💸 Se aplicó un impuesto de ${config.taxRate * 100}% (*${tax} coins*).\n` +
+                        `💰 *${targetUser.name}* recibió *${netAmount} coins*.\n\n` +
+                        `Tu nuevo saldo: ${senderUser.coins} coins.`;
 
     await sock.sendMessage(msg.key.remoteJid, { text: giveMessage, contextInfo: { mentionedJid: [mentionedJid] } }, { quoted: msg });
   }

--- a/plugins/rob.js
+++ b/plugins/rob.js
@@ -10,7 +10,7 @@ const robCommand = {
   description: "Intenta robar monedas a otro usuario. ¡Cuidado, puedes fallar!",
   aliases: ["robar"],
 
-  async execute({ sock, msg }) {
+  async execute({ sock, msg, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const robber = usersDb[senderId];
@@ -52,13 +52,17 @@ const robCommand = {
       // Éxito
       const stolenPercentage = Math.random() * (0.3 - 0.1) + 0.1; // Roba entre 10% y 30%
       const stolenAmount = Math.floor(victim.coins * stolenPercentage);
+      const tax = Math.floor(stolenAmount * config.taxRate);
+      const netStolen = stolenAmount - tax;
 
-      robber.coins += stolenAmount;
-      victim.coins -= stolenAmount;
+      robber.coins += netStolen;
+      victim.coins -= stolenAmount; // La víctima pierde el monto total
 
       writeUsersDb(usersDb);
 
-      const successMessage = `🚨 ¡Robo exitoso! 🚨\n\nLe has robado *${stolenAmount} coins* a *${victim.name}*.`;
+      const successMessage = `🚨 ¡Robo exitoso! 🚨\n\nLe has robado *${stolenAmount} coins* a *${victim.name}*.\n` +
+                             `💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n` +
+                             `💰 Ganancia neta: *${netStolen} coins*.`;
       await sock.sendMessage(msg.key.remoteJid, { text: successMessage, contextInfo: { mentionedJid: [mentionedJid] } }, { quoted: msg });
 
     } else {

--- a/plugins/slots.js
+++ b/plugins/slots.js
@@ -6,7 +6,7 @@ const slotsCommand = {
   description: "Juega a la máquina tragamonedas. Uso: slots <cantidad>",
   aliases: ["slot"],
 
-  async execute({ sock, msg, args }) {
+  async execute({ sock, msg, args, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const user = usersDb[senderId];
@@ -33,23 +33,29 @@ const slotsCommand = {
 
     const resultString = `[ ${results.join(" | ")} ]`;
     let winAmount = 0;
+    let tax = 0;
+    let netWin = 0;
     let winMessage = "";
 
     if (results[0] === results[1] && results[1] === results[2]) {
       // 3 of a kind
       winAmount = bet * 10;
-      winMessage = `¡JACKPOT! ¡Has ganado ${winAmount} coins! 🎉`;
+      tax = Math.floor(winAmount * config.taxRate);
+      netWin = winAmount - tax;
+      winMessage = `¡JACKPOT! ¡Has ganado ${winAmount} coins! 🎉\n(Impuesto: ${tax} coins)`;
     } else if (results[0] === results[1] || results[1] === results[2] || results[0] === results[2]) {
       // 2 of a kind
       winAmount = bet * 2;
-      winMessage = `¡Dos iguales! ¡Has ganado ${winAmount} coins!`;
+      tax = Math.floor(winAmount * config.taxRate);
+      netWin = winAmount - tax;
+      winMessage = `¡Dos iguales! ¡Has ganado ${winAmount} coins!\n(Impuesto: ${tax} coins)`;
     } else {
       // No win
-      winAmount = -bet;
+      netWin = -bet; // La pérdida es la apuesta completa
       winMessage = `¡Mala suerte! Has perdido ${bet} coins.`;
     }
 
-    user.coins += winAmount;
+    user.coins += netWin;
     writeUsersDb(usersDb);
 
     const finalMessage = `🎰 *Tragamonedas* 🎰\n\n${resultString}\n\n${winMessage}\n\n*Nuevo saldo:* ${user.coins} coins`;

--- a/plugins/work.js
+++ b/plugins/work.js
@@ -8,7 +8,7 @@ const workCommand = {
   description: "Trabaja para ganar monedas. Tiene un tiempo de espera de 1 hora.",
   aliases: ["trabajar"],
 
-  async execute({ sock, msg }) {
+  async execute({ sock, msg, config }) {
     const senderId = msg.sender;
     const usersDb = readUsersDb();
     const user = usersDb[senderId];
@@ -27,12 +27,18 @@ const workCommand = {
     }
 
     const earnings = Math.floor(Math.random() * (500 - 100 + 1)) + 100;
-    user.coins = (user.coins || 0) + earnings;
+    const tax = Math.floor(earnings * config.taxRate);
+    const netEarnings = earnings - tax;
+
+    user.coins = (user.coins || 0) + netEarnings;
     user.lastWork = now;
 
     writeUsersDb(usersDb);
 
-    const workMessage = `💪 Has trabajado duro y ganaste *${earnings} coins*.\nTu nuevo saldo es *${user.coins} coins*.`;
+    const workMessage = `💪 Has trabajado duro y ganaste *${earnings} coins*.\n` +
+                        `💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n` +
+                        `💰 Ganancia neta: *${netEarnings} coins*.\n` +
+                        `🏦 Tu nuevo saldo es *${user.coins} coins*.`;
     await sock.sendMessage(msg.key.remoteJid, { text: workMessage }, { quoted: msg });
   }
 };


### PR DESCRIPTION
- Adds a global `taxRate` of 10% to the bot's configuration.
- Modifies all economy commands that generate income (`work`, `crime`, `rob`, `slots`, `daily`, `give`) to apply this tax.
- Updates user-facing messages to show the tax deduction.