### PR TITLE
fix: remove deprecated printQRInTerminal option

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ async function connectToWhatsApp() {
     auth: state,
     logger,
     browser: ['JulesBot', 'Chrome', '1.0.0'],
-    printQRInTerminal: true,
   });
 
   // Adjuntar el handler principal al socket del bot principal


### PR DESCRIPTION
Removes the deprecated `printQRInTerminal: true` option from the Baileys connection configuration in `index.js`. This resolves the warning message logged on startup and is a step towards stabilizing the connection loop.