### PR TITLE
feat: implement item skill system (Stage 1)

### DIFF
--- a/plugins/fish.js
+++ b/plugins/fish.js
@@ -1,0 +1,53 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+
+const fishCommand = {
+  name: "fish",
+  category: "economia",
+  description: "Usa tu caña de pescar para conseguir monedas. Requiere una 'Caña de Pescar'.",
+  aliases: ["pescar"],
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+    const COOLDOWN_MS = 5 * 60 * 1000; // 5 minutos
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    // Verificar si el usuario tiene una caña de pescar
+    if (!user.inventory || !user.inventory.pesca || user.inventory.pesca < 1) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Necesitas una 'Caña de Pescar' para usar este comando. Cómprala en la tienda con `buy pesca`." }, { quoted: msg });
+    }
+
+    const lastFish = user.lastFish || 0;
+    const now = Date.now();
+
+    if (now - lastFish < COOLDOWN_MS) {
+      const timeLeft = COOLDOWN_MS - (now - lastFish);
+      const minutesLeft = Math.ceil(timeLeft / (1000 * 60));
+      return sock.sendMessage(msg.key.remoteJid, { text: `Debes esperar ${minutesLeft} minutos más para volver a pescar.` }, { quoted: msg });
+    }
+
+    const earnings = Math.floor(Math.random() * (75 - 10 + 1)) + 10;
+
+    // No hay impuestos para la pesca, es una ganancia menor.
+    user.coins = (user.coins || 0) + earnings;
+    user.lastFish = now;
+
+    writeUsersDb(usersDb);
+
+    const fishMessages = [
+        `¡Atrapaste una bota vieja! Pero encontraste ${earnings} coins dentro.`,
+        `¡Un pez dorado! Se vendió por ${earnings} coins.`,
+        `Pescaste un cofre pequeño con ${earnings} coins dentro.`,
+        `Una captura tranquila, pero valió ${earnings} coins.`
+    ];
+    const message = fishMessages[Math.floor(Math.random() * fishMessages.length)];
+
+    await sock.sendMessage(msg.key.remoteJid, { text: `🎣 ${message}\n*Nuevo saldo:* ${user.coins} coins` }, { quoted: msg });
+  }
+};
+
+export default fishCommand;

--- a/plugins/rob.js
+++ b/plugins/rob.js
@@ -48,7 +48,17 @@ const robCommand = {
 
     robber.lastRob = now; // Actualizar cooldown independientemente del resultado
 
-    if (Math.random() < SUCCESS_CHANCE) {
+    // Verificar si hay efectos activos
+    let currentSuccessChance = SUCCESS_CHANCE;
+    let luckActive = false;
+    if (robber.effects?.suerte && robber.effects.suerte > Date.now()) {
+      currentSuccessChance = 0.6; // Aumentar la probabilidad de éxito al 60%
+      luckActive = true;
+    } else if (robber.effects?.suerte) {
+      delete robber.effects.suerte; // Limpiar efecto expirado
+    }
+
+    if (Math.random() < currentSuccessChance) {
       // Éxito
       const stolenPercentage = Math.random() * (0.3 - 0.1) + 0.1; // Roba entre 10% y 30%
       const stolenAmount = Math.floor(victim.coins * stolenPercentage);
@@ -60,9 +70,14 @@ const robCommand = {
 
       writeUsersDb(usersDb);
 
-      const successMessage = `🚨 ¡Robo exitoso! 🚨\n\nLe has robado *${stolenAmount} coins* a *${victim.name}*.\n` +
-                             `💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n` +
-                             `💰 Ganancia neta: *${netStolen} coins*.`;
+      let successMessage = `🚨 ¡Robo exitoso! 🚨\n\nLe has robado *${stolenAmount} coins* a *${victim.name}*.\n` +
+                           `💸 Se dedujo un impuesto del ${config.taxRate * 100}% (*${tax} coins*).\n` +
+                           `💰 Ganancia neta: *${netStolen} coins*.`;
+
+      if (luckActive) {
+        successMessage += "\n\n✨ *¡Tu Poción de Suerte te ha ayudado!*";
+      }
+
       await sock.sendMessage(msg.key.remoteJid, { text: successMessage, contextInfo: { mentionedJid: [mentionedJid] } }, { quoted: msg });
 
     } else {

--- a/plugins/use.js
+++ b/plugins/use.js
@@ -1,0 +1,61 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import { shopItems } from '../lib/shop-items.js';
+
+const useCommand = {
+  name: "use",
+  category: "economia",
+  description: "Usa un artículo de tu inventario.",
+  aliases: ["usar"],
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado." }, { quoted: msg });
+    }
+
+    const itemIdToUse = args[0]?.toLowerCase();
+    if (!itemIdToUse) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Especifica el ID del artículo que quieres usar. Ejemplo: `use suerte`" }, { quoted: msg });
+    }
+
+    if (!user.inventory || !user.inventory[itemIdToUse] || user.inventory[itemIdToUse] < 1) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes "${itemIdToUse}" en tu inventario.` }, { quoted: msg });
+    }
+
+    const item = shopItems.find(i => i.id === itemIdToUse);
+    if (!item) {
+        // This case should be rare if inventory is managed properly
+        return sock.sendMessage(msg.key.remoteJid, { text: "Parece que tienes un artículo fantasma. No se puede usar." }, { quoted: msg });
+    }
+
+    // --- Lógica para cada artículo consumible ---
+    let effectApplied = false;
+    let effectMessage = "";
+
+    if (itemIdToUse === 'suerte') {
+      if (!user.effects) user.effects = {};
+      const twentyFourHours = 24 * 60 * 60 * 1000;
+      user.effects.suerte = Date.now() + twentyFourHours;
+      effectApplied = true;
+      effectMessage = "¡Has usado una Poción de Suerte! Tu probabilidad de éxito en los robos ha aumentado por 24 horas.";
+    } else {
+      return sock.sendMessage(msg.key.remoteJid, { text: `El artículo "${item.name}" no es un consumible o su efecto aún no ha sido implementado.` }, { quoted: msg });
+    }
+
+    if (effectApplied) {
+      // Decrementar o eliminar el artículo del inventario
+      user.inventory[itemIdToUse] -= 1;
+      if (user.inventory[itemIdToUse] <= 0) {
+        delete user.inventory[itemIdToUse];
+      }
+
+      writeUsersDb(usersDb);
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ ${effectMessage}` }, { quoted: msg });
+    }
+  }
+};
+
+export default useCommand;


### PR DESCRIPTION
- Adds a `fish` command that requires a 'Caña de Pescar' to use.
- Adds a `use` command for consumable items, starting with a 'Poción de Suerte'.
- Modifies the `rob` command to check for the 'suerte' effect, increasing its success chance.
- This lays the foundation for items to have functional effects in the game.