### PR TITLE
fix: final fixes for play command and sub-bot removal

### DIFF
--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,5 +1,37 @@
-import youtubedl from 'youtube-dl-exec';
+import { exec } from 'child_process';
 import yts from 'yt-search';
+import fs from 'fs';
+import path from 'path';
+
+// Helper function to run shell commands
+function runCommand(command) {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        return reject(error);
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+// Helper function to get a stream from yt-dlp
+async function getStream(url) {
+    // We will save to a temp file because getting buffer directly can be unstable with large files
+    const tempDir = './temp';
+    if (!fs.existsSync(tempDir)) {
+        fs.mkdirSync(tempDir);
+    }
+    const tempPath = path.join(tempDir, `${Date.now()}.mp3`);
+
+    // Command to download the best audio and save it to the temp file
+    const command = `yt-dlp -o "${tempPath}" -f bestaudio --extract-audio --audio-format mp3 --audio-quality 0 "${url}"`;
+
+    await runCommand(command);
+
+    return tempPath;
+}
+
 
 const playCommand = {
   name: "play",
@@ -12,10 +44,11 @@ const playCommand = {
     }
 
     const query = args.join(' ');
-    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `🎶 Buscando y procesando "${query}"...` }, { quoted: msg });
+    let waitingMsg;
 
     try {
-      // Usar yt-search para obtener el título correcto y la miniatura
+      waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `🎶 Buscando "${query}"...` }, { quoted: msg });
+
       const searchResults = await yts(query);
       if (!searchResults.videos.length) {
         throw new Error("No se encontraron resultados para tu búsqueda.");
@@ -23,30 +56,43 @@ const playCommand = {
       const videoInfo = searchResults.videos[0];
       const videoTitle = videoInfo.title;
 
-      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Encontrado: *${videoTitle}*.\n\n⬇️ Descargando audio...` }, { edit: waitingMsg.key });
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Encontrado: *${videoTitle}*.\n\n⬇️ Descargando... (esto puede tardar un poco)` }, { edit: waitingMsg.key });
 
-      // Usar youtube-dl-exec para descargar el audio
-      const audioUrl = await youtubedl(videoInfo.url, {
-        "get-url": true,
-        "format": "bestaudio/best",
-      });
+      const tempFilePath = await getStream(videoInfo.url);
+      const audioBuffer = fs.readFileSync(tempFilePath);
 
-      if (!audioUrl) {
-        throw new Error("No se pudo obtener el enlace de descarga del audio.");
-      }
-
+      // Enviar como audio reproducible
       await sock.sendMessage(
         msg.key.remoteJid,
         {
-          audio: { url: audioUrl },
+          audio: audioBuffer,
           mimetype: 'audio/mpeg'
         },
         { quoted: msg }
       );
 
+      // Enviar como documento
+      await sock.sendMessage(
+        msg.key.remoteJid,
+        {
+          document: audioBuffer,
+          mimetype: 'audio/mpeg',
+          fileName: `${videoTitle}.mp3`
+        },
+        { quoted: msg }
+      );
+
+      // Limpiar el archivo temporal
+      fs.unlinkSync(tempFilePath);
+
     } catch (error) {
       console.error("Error en el comando play:", error);
-      await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al procesar la solicitud de audio. Inténtalo de nuevo.`, edit: waitingMsg.key });
+      const errorMsg = { text: `Ocurrió un error al procesar la solicitud. Inténtalo de nuevo.` };
+      if (waitingMsg) {
+        await sock.sendMessage(msg.key.remoteJid, { ...errorMsg, edit: waitingMsg.key });
+      } else {
+        await sock.sendMessage(msg.key.remoteJid, errorMsg, { quoted: msg });
+      }
     }
   }
 };


### PR DESCRIPTION
- Deletes the `serbot` and `deletesesion` commands as requested.
- Implements a robust fix for the `play` command by downloading the audio to a local buffer before sending, and sending it as both playable audio and a document.
- This commit consolidates all features and fixes from the entire session into a final, stable version.