### PR TITLE
feat: implement robust fallback system for play and play2

### DIFF
--- a/plugins/play.js
+++ b/plugins/play.js
@@ -88,17 +88,16 @@ const playCommand = {
 
       // --- Sistema de Fallbacks ---
       try {
-        console.log("Intentando con el Método 1: yt-dlp");
+        // console.log("Intentando con el Método 1: yt-dlp");
         const tempFilePath = await downloadWithYtdlp(url);
         audioBuffer = fs.readFileSync(tempFilePath);
         fs.unlinkSync(tempFilePath); // Limpiar archivo temporal
-        source = "yt-dlp";
       } catch (e1) {
-        console.error("Método 1 (yt-dlp) falló:", e1.message);
-        await sock.sendMessage(msg.key.remoteJid, { text: `⚠️ Método 1 falló. Intentando con el Método 2...` }, { quoted: msg });
+        // console.error("Método 1 (yt-dlp) falló:", e1.message);
+        // await sock.sendMessage(msg.key.remoteJid, { text: `⚠️ Método 1 falló. Intentando con el Método 2...` }, { quoted: msg });
 
         try {
-            console.log("Intentando con el Método 2: ddownr");
+            // console.log("Intentando con el Método 2: ddownr");
             const downloadUrl = await downloadWithDdownr(url);
             const response = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
             audioBuffer = response.data;
@@ -113,7 +112,7 @@ const playCommand = {
         throw new Error("El buffer de audio está vacío después de todos los intentos.");
       }
 
-      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Descargado con éxito usando *${source}*. Enviando archivos...` }, { edit: waitingMsg.key });
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Descarga completada. Enviando archivos...` }, { edit: waitingMsg.key });
 
       // Enviar como audio reproducible
       await sock.sendMessage(msg.key.remoteJid, { audio: audioBuffer, mimetype: 'audio/mpeg' }, { quoted: msg });

--- a/plugins/play2.js
+++ b/plugins/play2.js
@@ -1,58 +1,119 @@
+import { exec } from 'child_process';
 import yts from 'yt-search';
-import youtubedl from 'youtube-dl-exec';
+import fs from 'fs';
+import path from 'path';
+import axios from 'axios';
+
+// --- Helper Functions for Downloading ---
+
+async function downloadWithYtdlp(url) {
+  const tempDir = './temp';
+  if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir);
+  const tempPath = path.join(tempDir, `${Date.now()}.mp4`);
+  const command = `yt-dlp -o "${tempPath}" -f "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best" --merge-output-format mp4 "${url}"`;
+
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) return reject(error);
+      if (!fs.existsSync(tempPath) || fs.statSync(tempPath).size === 0) return reject(new Error('yt-dlp downloaded an empty file.'));
+      resolve(tempPath);
+    });
+  });
+}
+
+async function downloadWithDdownr(url) {
+    const res = await axios.get(`https://p.oceansaver.in/ajax/download.php?format=720&url=${encodeURIComponent(url)}`);
+    if (!res.data?.success || !res.data.id) throw new Error("ddownr API: Failed to initiate conversion.");
+
+    for (let i = 0; i < 20; i++) {
+        const prog = await axios.get(`https://p.oceansaver.in/ajax/progress.php?id=${res.data.id}`);
+        if (prog.data?.success && prog.data.progress === 1000) {
+            const file = await axios.get(prog.data.download_url, { responseType: 'arraybuffer' });
+            return file.data;
+        }
+        await new Promise(resolve => setTimeout(resolve, 5000));
+    }
+    throw new Error("ddownr API: Conversion timed out.");
+}
+
+async function downloadWithApi(apiUrl) {
+    const response = await axios.get(apiUrl);
+    const result = response.data;
+    const downloadUrl = result?.result?.downloadUrl || result?.result?.url || result?.data?.dl || result?.dl;
+    if (!downloadUrl) throw new Error(`API ${apiUrl} did not return a valid download link.`);
+
+    const file = await axios.get(downloadUrl, { responseType: 'arraybuffer' });
+    return file.data;
+}
+
 
 const play2Command = {
   name: "play2",
   category: "descargas",
-  description: "Busca y descarga un video en formato MP4.",
+  description: "Busca y descarga un video en formato MP4 usando múltiples métodos.",
 
   async execute({ sock, msg, args }) {
-    if (args.length === 0) {
-      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona el nombre de un video." }, { quoted: msg });
-    }
+    if (args.length === 0) return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona el nombre de un video." }, { quoted: msg });
 
     const query = args.join(' ');
-    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `Buscando "${query}"...` }, { quoted: msg });
+    let waitingMsg;
 
     try {
-      const searchResult = await yts(query);
-      const video = searchResult.videos[0];
+      waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `🎶 Buscando "${query}"...` }, { quoted: msg });
 
-      if (!video) {
-        return sock.sendMessage(msg.key.remoteJid, { text: "No se encontraron resultados para tu búsqueda." }, { edit: waitingMsg.key });
+      const searchResults = await yts(query);
+      if (!searchResults.videos.length) throw new Error("No se encontraron resultados.");
+
+      const videoInfo = searchResults.videos[0];
+      const { title, url } = videoInfo;
+
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Encontrado: *${title}*.\n\n⬇️ Descargando video...` }, { edit: waitingMsg.key });
+
+      let videoBuffer;
+
+      // --- Fallback System ---
+      try {
+        const tempFilePath = await downloadWithYtdlp(url);
+        videoBuffer = fs.readFileSync(tempFilePath);
+        fs.unlinkSync(tempFilePath);
+      } catch (e1) {
+        console.error("yt-dlp failed:", e1.message);
+        try {
+          videoBuffer = await downloadWithDdownr(url);
+        } catch (e2) {
+          console.error("ddownr failed:", e2.message);
+          const fallbackApis = [
+            `https://api.siputzx.my.id/api/d/ytmp4?url=${encodeURIComponent(url)}`,
+            `https://mahiru-shiina.vercel.app/download/ytmp4?url=${encodeURIComponent(url)}`,
+            `https://api.agungny.my.id/api/youtube-video?url=${encodeURIComponent(url)}`
+          ];
+          let success = false;
+          for (const apiUrl of fallbackApis) {
+            try {
+              videoBuffer = await downloadWithApi(apiUrl);
+              success = true;
+              break;
+            } catch (e3) {
+              console.error(`API ${apiUrl} failed:`, e3.message);
+            }
+          }
+          if (!success) throw new Error("Todos los métodos de descarga de video han fallado.");
+        }
       }
 
-      await sock.sendMessage(msg.key.remoteJid, { text: `Procesando video para *${video.title}*...` }, { edit: waitingMsg.key });
+      if (!videoBuffer) throw new Error("El buffer de video está vacío.");
 
-      // Usa youtube-dl-exec para obtener el enlace de descarga directo
-      const downloadUrl = await youtubedl(video.url, {
-        getUrl: true,
-        format: 'best[ext=mp4][height<=720]/best[ext=mp4]'
-      });
+      await sock.sendMessage(msg.key.remoteJid, { text: `✅ Descarga completada. Enviando video...` }, { edit: waitingMsg.key });
 
-      if (!downloadUrl) {
-        throw new Error("No se pudo obtener la URL de descarga del video.");
-      }
-
-      await sock.sendMessage(
-        msg.key.remoteJid,
-        {
-          video: { url: downloadUrl },
-          mimetype: 'video/mp4',
-          caption: video.title
-        },
-        { quoted: msg }
-      );
+      await sock.sendMessage(msg.key.remoteJid, { video: videoBuffer, mimetype: 'video/mp4', caption: title }, { quoted: msg });
 
     } catch (error) {
-      console.error("Error en el comando play2:", error);
-      const errorMessage = error.message;
-      console.error("Detalle del error:", errorMessage);
-
-      if (error.stderr?.includes('proxy') || error.stderr?.includes('HTTP Error 429')) {
-        await sock.sendMessage(msg.key.remoteJid, { text: "El servicio de descarga está sobrecargado o bloqueado. Inténtalo más tarde." }, { edit: waitingMsg.key, quoted: msg });
+      console.error("Error final en play2:", error);
+      const errorMsg = { text: `❌ ${error.message}` };
+       if (waitingMsg) {
+        await sock.sendMessage(msg.key.remoteJid, { ...errorMsg, edit: waitingMsg.key });
       } else {
-        await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al procesar la solicitud de video.`, edit: waitingMsg.key, quoted: msg });
+        await sock.sendMessage(msg.key.remoteJid, errorMsg, { quoted: msg });
       }
     }
   }


### PR DESCRIPTION
- Rewrites `play` and `play2` commands to use a multi-stage, silent fallback system for maximum reliability.
- The primary download method is a local `yt-dlp` process.
- If the primary method fails, the commands fall back to using a series of public web APIs.
- Fallback process is silent to the user as requested.