### PR TITLE
feat: improve sticker command

### DIFF
--- a/plugins/sticker.js
+++ b/plugins/sticker.js
@@ -1,50 +1,79 @@
 import { downloadContentFromMessage } from '@whiskeysockets/baileys';
 import { Sticker, StickerTypes } from 'wa-sticker-formatter';
+import axios from 'axios';
+
+// Función para validar si un texto es una URL de imagen/video válida
+function isUrl(text) {
+    return /^https?:\/\/\S+\.(jpg|jpeg|png|gif|webp|mp4|webm)$/i.test(text);
+}
 
 const stickerCommand = {
   name: "sticker",
   category: "utilidades",
-  description: "Convierte una imagen o video corto en un sticker.",
-  aliases: ["s"],
+  description: "Convierte una imagen, video o URL en un sticker. Opcional: `sticker <pack> | <autor>`",
+  aliases: ["s", "stiker"],
 
-  async execute({ sock, msg, config }) {
+  async execute({ sock, msg, args, config }) {
     const from = msg.key.remoteJid;
     const quoted = msg.message?.extendedTextMessage?.contextInfo?.quotedMessage;
-    const messageType = quoted ? Object.keys(quoted)[0] : Object.keys(msg.message)[0];
+    const text = args.join(' ');
 
-    let mediaMessage;
-    if (quoted) {
-        mediaMessage = quoted;
-    } else if (msg.message.imageMessage || msg.message.videoMessage) {
-        mediaMessage = msg.message;
-    } else {
-        return sock.sendMessage(from, { text: "Responde a una imagen, video o envía una con el comando `sticker`." }, { quoted: msg });
+    let packname = config.botName || 'Bot';
+    let author = config.ownerName || 'Jules';
+
+    if (text.includes('|')) {
+        [packname, author] = text.split('|').map(s => s.trim());
     }
 
-    if (mediaMessage.videoMessage && mediaMessage.videoMessage.seconds > 10) {
-        return sock.sendMessage(from, { text: "El video es demasiado largo. El límite es de 10 segundos." }, { quoted: msg });
+    let mediaMessage;
+    let buffer;
+
+    // Prioridad 1: Mensaje citado
+    if (quoted) {
+        mediaMessage = quoted;
+    }
+    // Prioridad 2: Mensaje con imagen/video
+    else if (msg.message?.imageMessage || msg.message?.videoMessage) {
+        mediaMessage = msg.message;
     }
 
     try {
-      const stream = await downloadContentFromMessage(mediaMessage.imageMessage || mediaMessage.videoMessage, mediaMessage.imageMessage ? 'image' : 'video');
-      let buffer = Buffer.from([]);
-      for await(const chunk of stream) {
-        buffer = Buffer.concat([buffer, chunk]);
-      }
+        if (mediaMessage) {
+            if (mediaMessage.videoMessage && mediaMessage.videoMessage.seconds > 10) {
+                return sock.sendMessage(from, { text: "El video es demasiado largo. El límite es de 10 segundos." }, { quoted: msg });
+            }
+            const stream = await downloadContentFromMessage(mediaMessage.imageMessage || mediaMessage.videoMessage, mediaMessage.imageMessage ? 'image' : 'video');
+            buffer = Buffer.from([]);
+            for await(const chunk of stream) {
+                buffer = Buffer.concat([buffer, chunk]);
+            }
+        }
+        // Prioridad 3: URL en los argumentos
+        else if (args[0] && isUrl(args[0])) {
+            const url = args[0];
+            const response = await axios.get(url, { responseType: 'arraybuffer' });
+            buffer = response.data;
+        } else {
+            return sock.sendMessage(from, { text: "Responde a una imagen/video, o envía una URL, para crear un sticker." }, { quoted: msg });
+        }
 
-      const sticker = new Sticker(buffer, {
-        pack: config.botName || 'Bot',
-        author: config.ownerName || 'Jules',
-        type: StickerTypes.FULL,
-        quality: 50
-      });
+        if (!buffer) {
+            throw new Error("No se pudo obtener el medio para crear el sticker.");
+        }
 
-      const stickerBuffer = await sticker.toBuffer();
-      await sock.sendMessage(from, { sticker: stickerBuffer });
+        const sticker = new Sticker(buffer, {
+            pack: packname,
+            author: author,
+            type: StickerTypes.FULL,
+            quality: 50
+        });
+
+        const stickerBuffer = await sticker.toBuffer();
+        await sock.sendMessage(from, { sticker: stickerBuffer });
 
     } catch (e) {
-      console.error("Error en el comando sticker:", e);
-      await sock.sendMessage(from, { text: "Ocurrió un error al crear el sticker." }, { quoted: msg });
+        console.error("Error en el comando sticker:", e);
+        await sock.sendMessage(from, { text: "Ocurrió un error al crear el sticker. Asegúrate de que el medio sea válido." }, { quoted: msg });
     }
   }
 };


### PR DESCRIPTION
- Rewrites the sticker command to be more powerful and flexible.
- Uses the `wa-sticker-formatter` library.
- Adds support for creating stickers from direct URLs.
- Adds support for custom pack and author names, e.g., `.s My Pack | My Author`.