### PR TITLE
feat: add apk downloader command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@hapi/boom": "^9.1.4",
         "@vitalets/google-translate-api": "^9.2.0",
         "@whiskeysockets/baileys": "^6.7.2",
+        "aptoide-scraper": "^1.0.1",
         "axios": "^1.7.2",
         "chalk": "^5.3.0",
         "form-data": "^4.0.4",
@@ -934,6 +935,36 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aptoide-scraper": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/aptoide-scraper/-/aptoide-scraper-1.0.1.tgz",
+      "integrity": "sha512-YpN7rLtwoKfyXHC4N3j/SsUT9pCbulTe12be5QkGyjF/0dezdg9MXBUtcyANa2zD+Xs5cvyI2yR5rfG/Z2a9SA==",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.2.2",
+        "cheerio": "^1.0.0-rc.10",
+        "file_size_url": "^1.0.4",
+        "node-fetch": "^3.3.0"
+      }
+    },
+    "node_modules/aptoide-scraper/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1709,6 +1740,15 @@
       "integrity": "sha512-AFwspl5k7V8MW8H7tyIGJ0gtOauUg7JC+DgiRFUIXvPNNDFXTMtvnCkZY0macN6JLGqBjNP38WVnQN7Iv3RSlg==",
       "license": "MIT"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2419,6 +2459,35 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file_size_url": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/file_size_url/-/file_size_url-1.0.6.tgz",
+      "integrity": "sha512-lN41gCBrlsOM1BKujO/bPYpF75dlWbZHYSunfjHqyEPVEtjWWa7oGAdE68q+KWVXiElrNMfaRttb6IUaSkC8Pg==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2585,6 +2654,18 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-constants": {
@@ -3504,6 +3585,26 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -5014,6 +5115,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@hapi/boom": "^9.1.4",
     "@vitalets/google-translate-api": "^9.2.0",
     "@whiskeysockets/baileys": "^6.7.2",
+    "aptoide-scraper": "^1.0.1",
     "axios": "^1.7.2",
     "chalk": "^5.3.0",
     "form-data": "^4.0.4",

--- a/plugins/apk.js
+++ b/plugins/apk.js
@@ -1,0 +1,77 @@
+import { search, download } from 'aptoide-scraper';
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import axios from 'axios';
+
+const apkCommand = {
+  name: "apk",
+  category: "descargas",
+  description: "Busca y descarga una aplicación desde Aptoide. Cuesta 200 coins.",
+  aliases: ["modapk", "aptoide"],
+
+  async execute({ sock, msg, args }) {
+    const text = args.join(' ');
+    if (!text) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, ingrese el nombre de la apk para buscar." }, { quoted: msg });
+    }
+
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+    const cost = 200;
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    if (user.coins < cost) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes monedas para usar este comando. Necesitas ${cost} coins, pero solo tienes ${user.coins}.` }, { quoted: msg });
+    }
+
+    const waitingMsg = await sock.sendMessage(msg.key.remoteJid, { text: `🔎 Buscando "${text}" en Aptoide...` }, { quoted: msg });
+
+    try {
+      const searchResults = await search(text);
+      if (!searchResults || searchResults.length === 0) {
+        throw new Error("No se encontraron resultados para tu búsqueda.");
+      }
+
+      const appInfo = await download(searchResults[0].id);
+      if (!appInfo || !appInfo.dllink) {
+        throw new Error("No se pudo obtener la información de descarga de la aplicación.");
+      }
+
+      // Cobrar solo si la descarga es posible
+      user.coins -= cost;
+      writeUsersDb(usersDb);
+
+      let caption = `*乂  APTOIDE - DESCARGAS* 乂\n\n`;
+      caption += `☁️ *Nombre*: ${appInfo.name}\n`;
+      caption += `📦 *Package*: ${appInfo.package}\n`;
+      caption += `⬆️ *Actualizado*: ${appInfo.lastup}\n`;
+      caption += `⚖️ *Peso*: ${appInfo.size}\n\n`;
+      caption += `💸 *Costo:* 200 coins.`;
+
+      await sock.sendMessage(msg.key.remoteJid, { image: { url: appInfo.icon }, caption: caption }, { quoted: msg });
+
+      await sock.sendMessage(msg.key.remoteJid, { text: "Enviando APK como documento..." }, { edit: waitingMsg.key });
+
+      if (appInfo.size.includes('GB') || parseFloat(appInfo.size.replace(' MB', '')) > 150) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "El archivo es demasiado pesado para ser enviado (> 150 MB)." }, { quoted: msg });
+      }
+
+      await sock.sendMessage(msg.key.remoteJid, {
+        document: { url: appInfo.dllink },
+        mimetype: 'application/vnd.android.package-archive',
+        fileName: `${appInfo.name}.apk`
+      }, { quoted: msg });
+
+    } catch (error) {
+      console.error("Error en el comando apk:", error);
+      // No se devuelve el dinero si el error ocurre después de cobrar,
+      // ya que el enlace de descarga se obtuvo, el fallo puede ser de WhatsApp.
+      await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un fallo: ${error.message}` }, { quoted: msg, edit: waitingMsg.key });
+    }
+  }
+};
+
+export default apkCommand;


### PR DESCRIPTION
- Adds a new `apk` command to search for and download Android applications from Aptoide.
- The command costs 200 coins per use, which is deducted from the user's balance.
- Uses the `aptoide-scraper` library.