### PR TITLE
feat: Add auto-restart functionality to the start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -22,4 +22,8 @@ echo ">>> [Paso 2/3] Instalando/actualizando dependencias de Node.js..."
 npm install --silent
 
 echo ">>> [Paso 3/3] Iniciando el bot..."
-node index.js
+while true; do
+    node index.js
+    echo ">>> ¡El bot se ha detenido! Reiniciando en 1 segundo..."
+    sleep 1
+done


### PR DESCRIPTION
This commit modifies the `start.sh` script to automatically restart the bot if it crashes or stops for any reason.

The `node index.js` command is now wrapped in a `while true` loop. If the node process exits, the script will wait for 1 second and then start it again. This ensures higher availability for the bot.