### PR TITLE
feat: Add owner-only shutdown command

### DIFF
--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -1,0 +1,22 @@
+const shutdownCommand = {
+  name: "shutdown",
+  category: "propietario",
+  description: "Apaga el bot. Este comando solo puede ser usado por el propietario.",
+  aliases: ["apagar"],
+
+  async execute({ sock, msg }) {
+    try {
+      await sock.sendMessage(msg.key.remoteJid, { text: "✅ Apagando el bot..." }, { quoted: msg });
+      // Un pequeño retraso para asegurar que el mensaje se envíe antes de apagar.
+      setTimeout(() => {
+        process.exit(0);
+      }, 1000);
+    } catch (e) {
+      console.error("Error en el comando shutdown:", e);
+      // Si hay un error, al menos intenta apagar el proceso.
+      process.exit(1);
+    }
+  }
+};
+
+export default shutdownCommand;


### PR DESCRIPTION
This commit introduces a new `shutdown` command that allows the bot owner to stop the process.

The command is defined in `plugins/shutdown.js` and is restricted to the owner by setting `category: 'propietario'`. The existing command handler already prevents non-owners from executing commands in this category.

When executed, the command sends a confirmation message and then exits the process. This is useful for testing the auto-restart functionality.