### PR TITLE
fix: Ensure shutdown command triggers auto-restart

### DIFF
--- a/plugins/shutdown.js
+++ b/plugins/shutdown.js
@@ -9,7 +9,7 @@ const shutdownCommand = {
       await sock.sendMessage(msg.key.remoteJid, { text: "✅ Apagando el bot..." }, { quoted: msg });
       // Un pequeño retraso para asegurar que el mensaje se envíe antes de apagar.
       setTimeout(() => {
-        process.exit(0);
+        process.exit(1);
       }, 1000);
     } catch (e) {
       console.error("Error en el comando shutdown:", e);


### PR DESCRIPTION
This commit changes the exit code in the `shutdown` command from 0 to 1.

The previous implementation used `process.exit(0)`, which signals a successful exit. This was likely causing the `npm` process or the parent shell to terminate the `start.sh` script's loop, preventing the bot from restarting.

By changing the exit code to 1, we signal an abnormal termination, which ensures the `while` loop in `start.sh` continues and restarts the bot as intended.